### PR TITLE
chore: ci 1.11 to match mix version

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,6 +14,9 @@ jobs:
         exclude:
         - otp: '25.0'
           elixir: '1.12.3'
+        include:
+        - otp: '24.3'
+          elixir: '1.11.4'
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
Build against the minimum supported version